### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Now edit the `init` action in `src/frontend/controllers/controller.js` so that y
 
 Once it's done, you just need to refresh your browser.
 
-Gina is shipped with [Swig](http://paularmstrong.github.io/swig/docs/) as the default template engine. If you are more confortable with another template engine, you can use your own.
+Gina is shipped with [Swig](http://paularmstrong.github.io/swig/docs/) as the default template engine. If you are more comfortable with another template engine, you can use your own.
 
 
 ## Troubleshooting


### PR DESCRIPTION
@Rhinostone, I've corrected a typographical error in the documentation of the [gina](https://github.com/Rhinostone/gina) project. Specifically, I've changed confortable to comfortable. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.