### PR TITLE
Bundle-compat fixes: setTemplate API, init-order bug fixes, nunjucks/swig parity

### DIFF
--- a/framework/v0.3.12/core/controller/controller.js
+++ b/framework/v0.3.12/core/controller/controller.js
@@ -1057,6 +1057,40 @@ function SuperController(options) {
      * @param {boolean} [displayInspector] - Show the Gina dev inspector when `true`
      * @returns {void}
      */
+    /**
+     * Override the route's default template path / extension at action time.
+     *
+     * Use case: a controller action that resolves the template dynamically
+     * (e.g. a catch-all router that picks the template by URL pattern). With
+     * Gina's standard 1:1 routing.json → template mapping the rule's
+     * `param.file` is sufficient, but dynamic dispatch needs a runtime
+     * override that survives until render-time.
+     *
+     * The render delegates (controller.render-nunjucks.js,
+     * controller.render-swig.js) read `localOptions._templateOverride`
+     * before falling back to `data.page.view.file`/`.ext`. Setting this
+     * after `setOptions()` has already populated `data.page.view.*` is the
+     * supported way to redirect rendering from inside an action — that
+     * eviction-order is otherwise unreachable from controller code because
+     * `local.options` is closure-private.
+     *
+     * @memberof BaseController
+     * @param {string} file - Template path relative to the bundle's
+     *                        templates root (no extension; pass `ext` separately).
+     * @param {string} [ext] - File extension (with or without leading dot).
+     *                         Defaults to whatever `data.page.view.ext` carries.
+     */
+    this.setTemplate = function (file, ext) {
+        if (!local.options) return; // setOptions hasn't run yet — bail safely
+        if (!local.options._templateOverride) local.options._templateOverride = {};
+        if (typeof file === 'string') {
+            local.options._templateOverride.file = file;
+        }
+        if (typeof ext === 'string' && ext) {
+            local.options._templateOverride.ext = (ext.charAt(0) === '.') ? ext : ('.' + ext);
+        }
+    };
+
     this.renderWithoutLayout = function (data, displayInspector) {
 
         // preventing multiple call of self.renderWithoutLayout() when controller is rendering from another required controller

--- a/framework/v0.3.12/core/controller/controller.render-nunjucks.js
+++ b/framework/v0.3.12/core/controller/controller.render-nunjucks.js
@@ -202,6 +202,17 @@ function getEnvironment(nunjucks, templateRoot, options) {
  * @returns {string} relative template path
  */
 function resolveTemplatePath(data, localOptions) {
+    // Honour controller-set override from self.setTemplate(file, ext).
+    // When set, the override fully replaces the rule's default path —
+    // no namespace prefixing — so a catch-all dispatcher can drop the
+    // controller anywhere under the templates root.
+    if (localOptions && localOptions._templateOverride && localOptions._templateOverride.file) {
+        var ovFile = localOptions._templateOverride.file;
+        var ovExt  = localOptions._templateOverride.ext || data.page.view.ext || '';
+        if (ovExt && !ovFile.endsWith(ovExt)) ovFile += ovExt;
+        return ovFile;
+    }
+
     var file = data.page.view.file;
     var ext  = data.page.view.ext || '';
 
@@ -548,6 +559,67 @@ function registerGinaFilters(env, self, local, localOptions, req, res) {
 }
 
 /**
+ * Invoke the bundle's `controllers/setup.js` (if any) with `this.engine`
+ * bound to the cached `nunjucks.Environment`, so user code can call
+ * `engine.addFilter(name, fn)` to extend filters on the nunjucks side
+ * the same way it already can on swig (where `self.engine = swig` is
+ * set by `controller.js:735` before setup runs).
+ *
+ * Without this hook, every nunjucks bundle that uses the documented
+ * setup.js pattern (`var engine = this.engine; engine.addFilter(...)`)
+ * silently no-ops because `this.engine` arrives as the controller's
+ * default `{}` — the nunjucks engine is created lazily here in the
+ * render delegate, after the controller's onReady→setup chain has
+ * already fired.
+ *
+ * Run once per `nunjucks.Environment` instance: marker `_userSetupDone`
+ * is stamped on the env itself so re-renders are no-ops, and a fresh
+ * env (e.g. after `nunjucksResolver.reset()`) re-runs setup.
+ *
+ * @inner
+ * @param {*}      env          - cached `nunjucks.Environment`
+ * @param {object} self         - SuperController instance (provides throwError)
+ * @param {object} local        - per-request closure (`req`, `res`, `next`)
+ * @param {object} localOptions - controller's localOptions (has `bundle`, `conf.bundlesPath`)
+ * @returns {void}
+ */
+function registerUserFilters(env, self, local, localOptions) {
+    if (env._userSetupDone) return;
+    if (!localOptions || !localOptions.bundle || !localOptions.conf || !localOptions.conf.bundlesPath) return;
+
+    var setupFile = localOptions.conf.bundlesPath + '/' + localOptions.bundle + '/controllers/setup.js';
+    if (!fs.existsSync(setupFile)) {
+        env._userSetupDone = true; // no setup.js — nothing to do, don't recheck
+        return;
+    }
+
+    var Setup;
+    try {
+        Setup = require(setupFile);
+    } catch (loadErr) {
+        try { console.warn('[render-nunjucks] failed to load user setup.js (' + setupFile + '): ' + (loadErr.message || loadErr)); } catch (e) {}
+        env._userSetupDone = true;
+        return;
+    }
+
+    if (typeof Setup !== 'function') {
+        env._userSetupDone = true;
+        return;
+    }
+
+    Setup.engine     = env;
+    Setup.throwError = self.throwError;
+
+    try {
+        Setup.apply(Setup, [local.req, local.res, local.next]);
+    } catch (setupErr) {
+        try { console.warn('[render-nunjucks] user setup.js threw: ' + (setupErr.message || setupErr)); } catch (e) {}
+    }
+
+    env._userSetupDone = true;
+}
+
+/**
  * Post-render asset injection — the nunjucks counterpart to the pre-compile
  * layout mutation in `render-swig.js:963-1195`. Idempotent and safe to call
  * on arbitrary HTML: every insertion is guarded against double-injection
@@ -832,15 +904,34 @@ module.exports = async function renderNunjucks(userData, displayInspector, errOp
         ));
     }
 
-    // Merge user data into page.data so templates can access via {{ page.data.foo }}
-    // or {{ foo }} at top level (promoted for ergonomic parity with swig).
-    // FRAMEWORK PATCH: the comment promised top-level promotion but
-    // the original code only wrote to data.page.data. Mirror to top-level too.
+    // Merge user data into the render context, mirroring `render-swig.js:480-517`.
+    // Swig does two things to userData:
+    //
+    //   (a) Branching stash — if userData has no `page` key, copy it into
+    //       `data.page.data`. If userData has a `page` key, skip the stash.
+    //   (b) Unconditional top-level merge — userData wins on collision with
+    //       framework-populated keys, matching swig's `merge(data, getData())`.
+    //
+    // Without (b), nunjucks templates that mirror swig-style usage
+    // (`{{ client }}`, `{{ settings.terms.estimate }}`) silently render
+    // empty when the controller passes a flat object — `for` loops iterate
+    // 0 times, `set e = estimate` binds undefined, etc.
     if (userData && typeof(userData) === 'object') {
-        if (!data.page.data) { data.page.data = {}; }
+        // (a) Branching stash
+        if (!userData.page) {
+            if (!data.page.data) { data.page.data = {}; }
+            Object.keys(userData).forEach(function (k) {
+                data.page.data[k] = userData[k];
+            });
+        }
+        // (b) Unconditional top-level merge — userData wins; userData.page
+        // merges INTO data.page (preserves framework-injected page.view etc.).
         Object.keys(userData).forEach(function (k) {
-            data.page.data[k] = userData[k];
-            if (typeof(data[k]) === 'undefined') {
+            if (k === 'page' && data.page && typeof userData.page === 'object') {
+                Object.keys(userData.page).forEach(function (pk) {
+                    data.page[pk] = userData.page[pk];
+                });
+            } else {
                 data[k] = userData[k];
             }
         });
@@ -875,6 +966,16 @@ module.exports = async function renderNunjucks(userData, displayInspector, errOp
         registerGinaFilters(env, self, local, localOptions, req, res);
     } catch (filterErr) {
         return self.throwError(filterErr);
+    }
+
+    // #NJ1b — give the bundle's controllers/setup.js a chance to extend
+    // filters via `this.engine.addFilter(...)`, mirroring the swig path
+    // where `self.engine = swig` is set in controller.js before setup runs.
+    // No-op if no setup.js exists or it doesn't add filters.
+    try {
+        registerUserFilters(env, self, local, localOptions);
+    } catch (userFilterErr) {
+        try { console.warn('[render-nunjucks] registerUserFilters failed: ' + (userFilterErr.message || userFilterErr)); } catch (e) {}
     }
 
     // #NJ2 — build the per-request template config and populate

--- a/framework/v0.3.12/core/server.isaac.js
+++ b/framework/v0.3.12/core/server.isaac.js
@@ -64,15 +64,30 @@ var refreshCore = function() {
         }
     }
 
-    // Update lib & helpers
-    delete require.cache[require.resolve(_(libPath +'/index.js', true))];
-    require.cache[_(libPath +'/index.js', true)] = require( _(libPath +'/index.js', true) );
-    require.cache[_(corePath + '/gna.js', true)].exports.lib = require.cache[_(libPath +'/index.js', true)];
+    // Update lib & helpers.
+    //
+    // Pre-fix bug: line `require.cache[<path>] = require(<path>)` overwrote the
+    // require.cache entry — which Node expects to be a `Module` instance with
+    // an `.exports` property — with the lib registry's *exports object* directly.
+    // Subsequent `require('../../lib')` calls then read `require.cache[<path>].exports`
+    // and got `undefined` (the registry has no `.exports` key), surfacing as
+    // `Cannot read properties of undefined (reading 'Collection')` /
+    // `(reading 'Cache')` / etc. inside controller.render-nunjucks.js.
+    //
+    // Fix: just delete the cache entry and let the next require() re-evaluate
+    // the module the normal way. Node will rebuild the Module instance with a
+    // fresh `.exports`. Then update gna.js's captured `.lib` reference to point
+    // at the new exports. Same applies to the plugins entry below.
+    var libIndexPath = _(libPath +'/index.js', true);
+    delete require.cache[require.resolve(libIndexPath)];
+    var freshLib = require( libIndexPath );
+    require.cache[_(corePath + '/gna.js', true)].exports.lib = freshLib;
 
     // Update plugins
-    delete require.cache[require.resolve(_(corePath +'/plugins/index.js', true))];
-    require.cache[_(corePath +'/plugins/index.js', true)] = require( _(corePath +'/plugins/index.js', true) );
-    require.cache[_(corePath + '/gna.js', true)].exports.plugins = require.cache[_(corePath +'/plugins/index.js', true)];
+    var pluginsIndexPath = _(corePath +'/plugins/index.js', true);
+    delete require.cache[require.resolve(pluginsIndexPath)];
+    var freshPlugins = require( pluginsIndexPath );
+    require.cache[_(corePath + '/gna.js', true)].exports.plugins = freshPlugins;
 }
 
 // Express compatibility

--- a/framework/v0.3.12/lib/index.js
+++ b/framework/v0.3.12/lib/index.js
@@ -20,8 +20,26 @@
 //var merge = require('./merge');
 
 /**
- * Library registry constructor — returns a plain object `self`, not `this`.
- * Consumed via `lib = new Lib()` in `gna.js`.
+ * Library registry constructor — mutates `module.exports` in place rather
+ * than returning a fresh object so that any consumer that captures a
+ * reference to `require('./lib')` (or `require('../../lib')`, etc.) before
+ * Lib() finishes executing still ends up with the fully-populated registry
+ * once construction completes. This breaks the `Cannot read properties of
+ * undefined (reading 'X')` class of failures we hit when dev-mode hot-reload
+ * (controller.js's per-render eviction of `controller.render-<engine>.js`)
+ * re-evaluates a controller delegate while lib/index.js is mid-load.
+ *
+ * Pre-fix: `lib = new Lib()` returned a fresh `self`, then
+ * `module.exports = lib` ran at the very end of the file. Anything the
+ * `_require('./...')` calls below transitively required-back saw the
+ * initial empty `module.exports = {}` because the assignment hadn't
+ * happened yet; their captured references never updated.
+ *
+ * Post-fix: `self === module.exports`. Properties land on the *same* object
+ * reference every captured `require('../../lib')` already holds, so
+ * `require('../../lib').Collection` resolves correctly the moment Lib()
+ * has assigned that property — including when the require'r is hit before
+ * Lib() returns.
  *
  * @class Lib
  * @constructor
@@ -42,7 +60,8 @@ function Lib() {
 
 
 
-    var self = {
+    var self = module.exports;
+    Object.assign(self, {
         Config          : _require('./config'),
         //dev     : require('./lib/dev'),//must be at the same level than gina.lib => gina.dev
         inherits        : _require('./inherits'),
@@ -128,7 +147,7 @@ function Lib() {
         // instance with an HTTP endpoint (POST, JSON/SSE negotiation, batch,
         // Mcp-Session-Id lifecycle). Auth / Origin checks land in Phase 2b S2.
         mcpHttp         : _require('./mcp-http'),
-    };
+    });
 
     /**
      * Strip macOS dot-files (`.DS_Store`, `._*`, etc.) from a directory listing.
@@ -151,8 +170,12 @@ function Lib() {
 
     return self
 }
-// Making it global
+// Making it global. `new Lib()` mutates `module.exports` in place and returns
+// the same reference, so `lib === module.exports` post-construction.
 lib = new Lib();
+// `module.exports = lib` at the bottom of this file is now redundant (the
+// assignment in Lib() is what populates the export), but kept as a no-op
+// cap for symmetry with the pre-fix version and as a clear reading anchor.
 
 /**
  * Bootstrap the command dispatcher when running inside the daemon process.


### PR DESCRIPTION
## Context

Four patches uncovered while running a downstream Nunjucks bundle (`@designsystem` for [freelancerapp/design-system](https://github.com/freelancerapp/design-system)) against v0.3.9-alpha.2, re-verified against v0.3.12. They split cleanly into three categories — happy to split into separate PRs if you'd prefer to land them at different speeds.

Verified against `gina-io/gina@v0.3.12` (`6ea110e4`); applies cleanly with no rejects.

## Commits

### A. Bug fixes (init-order / hot-reload correctness) — low risk, no semantic change

- **`Fixing refreshCore() require.cache rebuild — Module vs exports mix-up`** (`core/server.isaac.js`)
  Pre-fix `require.cache[<path>] = require(<path>)` overwrote `require.cache`'s `Module` entry with the registry's *exports object* directly. Subsequent `require()` reads `.exports` off the wrong type → `undefined`, surfacing as `Cannot read properties of undefined (reading 'Collection')` after dev-mode hot reload. Fix: delete + re-require.

- **`Fixing Lib() init-order race by mutating module.exports in place`** (`lib/index.js`)
  Pre-fix `Lib()` returned a fresh `self` with `module.exports = lib` only assigned at file's end. Anything `_require()`'d transitively during Lib() load saw the initial empty exports; captured refs never updated. Fix: `Object.assign(module.exports, {...})`.

### B. New feature (additive, no behavior change for non-callers)

- **`Adding self.setTemplate(file, ext) controller API for runtime template override`** (`core/controller/controller.js`)
  Public controller method to override the rule's default template path/ext at action time. Writes `local.options._templateOverride`. Needed for dynamic-dispatch controllers (catch-all routers, error-template redirects).

- **First hunk of `Closing three nunjucks render-delegate gaps...`** (`core/controller/controller.render-nunjucks.js`, `resolveTemplatePath()`)
  Render-side consumer for the API above. When `_templateOverride.file` is set, fully replaces the rule's default path with no namespace prefixing.

### C. Nunjucks/swig parity (the more discussable one)

Both edits live in `core/controller/controller.render-nunjucks.js` (commit 4, hunks 2-3):

- **`registerUserFilters()` — invokes bundle's `controllers/setup.js` with `this.engine = env`**
  Swig path runs `setup.js` with `this.engine = swig` (controller.js:735) so user code can do `engine.addFilter(name, fn)`. The nunjucks path created the env lazily *inside* the render delegate — after `setup.js` had already run with `this.engine = {}` — so the documented pattern silently no-op'd for every nunjucks bundle. Patch re-invokes `setup.js` once the env exists, idempotent via `env._userSetupDone`.

- **`userData` merge mirrors `render-swig.js:480-517`**
  Pre-fix only filled top-level `data[k]` when undefined (framework wins collisions). Swig does `merge(data, getData())` unconditionally (userData wins). Without this, nunjucks templates that mirror swig-style usage (`{{ client }}`, `{{ settings.terms.estimate }}`) render empty when the controller passes a flat object — templates pick the wrong layout branch. Patch adds branching stash + unconditional top-level merge, with `userData.page` merging INTO `data.page` (preserves `data.page.view` etc.).

## Test coverage

Downstream Playwright suite (146 tests across nunjucks-rendered pages, dialogs, and visual regressions) passes 145/146 against v0.3.12 + these patches. The remaining failure is a pre-existing parallel-load flake unrelated to gina.

## Split-PR offer

If the reviewer prefers narrower review, happy to resubmit as:
- **PR A** (commits 1-2) — bug fixes only
- **PR B** (commits 3-4 hunk 1) — `setTemplate` feature
- **PR C** (commit 4 hunks 2-3) — nunjucks/swig parity
