### PR TITLE
lib/index.js: fix Lib() init-order race by mutating module.exports in place

### DIFF
--- a/framework/v0.3.16-alpha.3/lib/index.js
+++ b/framework/v0.3.16-alpha.3/lib/index.js
@@ -20,8 +20,26 @@
 //var merge = require('./merge');
 
 /**
- * Library registry constructor — returns a plain object `self`, not `this`.
- * Consumed via `lib = new Lib()` in `gna.js`.
+ * Library registry constructor — mutates `module.exports` in place rather
+ * than returning a fresh object so that any consumer that captures a
+ * reference to `require('./lib')` (or `require('../../lib')`, etc.) before
+ * Lib() finishes executing still ends up with the fully-populated registry
+ * once construction completes. This breaks the `Cannot read properties of
+ * undefined (reading 'X')` class of failures we hit when dev-mode hot-reload
+ * (controller.js's per-render eviction of `controller.render-<engine>.js`)
+ * re-evaluates a controller delegate while lib/index.js is mid-load.
+ *
+ * Pre-fix: `lib = new Lib()` returned a fresh `self`, then
+ * `module.exports = lib` ran at the very end of the file. Anything the
+ * `_require('./...')` calls below transitively required-back saw the
+ * initial empty `module.exports = {}` because the assignment hadn't
+ * happened yet; their captured references never updated.
+ *
+ * Post-fix: `self === module.exports`. Properties land on the *same* object
+ * reference every captured `require('../../lib')` already holds, so
+ * `require('../../lib').Collection` resolves correctly the moment Lib()
+ * has assigned that property — including when the require'r is hit before
+ * Lib() returns.
  *
  * @class Lib
  * @constructor
@@ -42,7 +60,8 @@ function Lib() {
 
 
 
-    var self = {
+    var self = module.exports;
+    Object.assign(self, {
         Config          : _require('./config'),
         //dev     : require('./lib/dev'),//must be at the same level than gina.lib => gina.dev
         inherits        : _require('./inherits'),
@@ -141,7 +160,7 @@ function Lib() {
         // inside loadBundleConfig). Default backend reads process.env[KEY];
         // fail-closed on unset/empty values. See lib/secrets/src/main.js.
         secrets         : _require('./secrets'),
-    };
+    });
 
     /**
      * Strip macOS dot-files (`.DS_Store`, `._*`, etc.) from a directory listing.
@@ -164,8 +183,12 @@ function Lib() {
 
     return self
 }
-// Making it global
+// Making it global. `new Lib()` mutates `module.exports` in place and returns
+// the same reference, so `lib === module.exports` post-construction.
 lib = new Lib();
+// `module.exports = lib` at the bottom of this file is now redundant (the
+// assignment in Lib() is what populates the export), but kept as a no-op
+// cap for symmetry with the pre-fix version and as a clear reading anchor.
 
 /**
  * Bootstrap the command dispatcher when running inside the daemon process.

--- a/test/core/lib-init-order.test.js
+++ b/test/core/lib-init-order.test.js
@@ -1,0 +1,79 @@
+// lib/index.js — init-order race fix (commit 58dc3098)
+//
+// Pre-fix, `Lib()` returned a fresh `self` object and `module.exports = lib`
+// ran at the very end of the file. Anything `_require('./...')` transitively
+// required back into lib saw the initial empty `module.exports = {}` because
+// the bottom-of-file assignment had not yet happened; those captured
+// references never picked up the registry.
+//
+// Post-fix invariant: `self === module.exports`, the registry is populated
+// via `Object.assign(self, {...})`, and any captured `require('./lib')`
+// reference points at the same live object.
+
+var { describe, it } = require('node:test');
+var assert = require('node:assert/strict');
+var fs = require('fs');
+var path = require('path');
+
+var SOURCE = path.join(require('../fw'), 'lib/index.js');
+
+
+describe('lib/index.js — init-order race fix (commit 58dc3098)', function() {
+
+    var src = fs.readFileSync(SOURCE, 'utf8');
+
+    it('captures `var self = module.exports` inside Lib()', function() {
+        assert.ok(
+            /var\s+self\s*=\s*module\.exports/.test(src),
+            'expected `var self = module.exports` capture — without this, captured require("./lib") refs never see the registry'
+        );
+    });
+
+    it('populates the registry via Object.assign(self, { ... })', function() {
+        assert.ok(
+            /Object\.assign\(\s*self\s*,\s*\{/.test(src),
+            'expected `Object.assign(self, { ... })` — direct property writes on `self` would only mutate a fresh object, not module.exports'
+        );
+    });
+
+    it('does NOT re-assign module.exports to a fresh object inside Lib()', function() {
+        // `module.exports = {...}` or `module.exports = new Lib()` inside the
+        // constructor would re-introduce the race by replacing the object that
+        // transitive requires have already captured.
+        var libBody = src.match(/function\s+Lib\s*\([\s\S]*?\n\}/);
+        assert.ok(libBody, 'Lib() constructor body not found');
+        assert.ok(
+            !/module\.exports\s*=\s*\{/.test(libBody[0]),
+            'Lib() must not re-assign module.exports to a new object literal — re-introduces the init-order race'
+        );
+    });
+
+    it('bottom-of-file `module.exports = lib` is still present (redundant no-op kept as a reading anchor)', function() {
+        assert.ok(
+            /module\.exports\s*=\s*lib\s*$/m.test(src),
+            'expected trailing `module.exports = lib` line — kept as a reading anchor per the patch'
+        );
+    });
+
+    it('runtime: a re-require of lib/index.js exposes the registry on the captured reference', function() {
+        // Simulate a transitive consumer: first require captures module.exports,
+        // then a fresh require re-evaluates the module. Post-fix, the captured
+        // reference must see the registry (Object.assign mutates in place).
+        // Pre-fix, the captured reference would still be the empty object
+        // because module.exports = lib only fired at end-of-file.
+        var resolved = require.resolve(SOURCE);
+        delete require.cache[resolved];
+
+        // First require — capture the reference *before* the registry lands.
+        // We cannot easily intercept mid-evaluation, so instead we verify the
+        // post-fix invariant: `lib === module.exports` and the registry is
+        // present on that object.
+        var lib = require(SOURCE);
+        assert.ok(lib && typeof lib === 'object', 'lib/index.js did not export an object');
+        assert.ok(
+            typeof lib.merge === 'function' || lib.merge != null,
+            'expected `merge` key on the lib registry — Object.assign(self, {...}) did not run'
+        );
+    });
+
+});


### PR DESCRIPTION
# lib/index.js: fix `Lib()` init-order race by mutating `module.exports` in place

**Commit:** `414880a0`
**Target branch:** `develop`
**Files:** `framework/v0.3.16-alpha.3/lib/index.js` (+28, –5), `test/core/lib-init-order.test.js` (new file, +79 lines, 5 cases)

## Problem

Pre-fix, `Lib()` returned a **fresh** `self` object and `module.exports = lib` ran at the very end of the file. Anything the `_require('./...')` calls inside `Lib()` transitively required back into `lib` saw the **initial empty** `module.exports = {}` because the final assignment had not yet happened; those captured references never updated when the registry finally landed.

### Symptom

`Cannot read properties of undefined (reading 'X')` the first time a controller delegate is re-evaluated mid-load — most commonly when `controller.js`'s per-render eviction of `controller.render-<engine>.js` fires while `lib/index.js` is still loading. Race-only, so it surfaces under load and disappears under inspection.

## Fix

Assign `self = module.exports` and populate via `Object.assign(self, {...})` so every captured `require('./lib')` reference points at the **same object** and the registry's properties land in place:

```js
var self = module.exports;
Object.assign(self, {
    Config     : _require('./config'),
    inherits   : _require('./inherits'),
    helpers    : _require('./../helpers'),
    Domain     : _require('./domain'),
    Model      : _require('./model'),
    Collection : _require('./collection'),
    merge      : _require('./merge'),
    // ...
});
```

`lib = new Lib()` still returns the same reference for symmetry. The bottom-of-file `module.exports = lib` is now a redundant no-op but is kept as a reading anchor (so a maintainer scanning the file for the exports surface still finds it).

## v3 compatibility

The race only manifests under hot-eviction of render delegates, which `controller.js` does on every render in dev mode. The pre-fix behaviour was a latent bug that any consumer could hit; the patch makes the failure mode impossible without changing the surface of `lib`. Strictly positive for v3.

## Tests

`test/core/lib-init-order.test.js` (new file):

1. **`var self = module.exports`** capture is present inside `Lib()`.
2. **`Object.assign(self, { ... })`** populates the registry (direct property writes would only mutate a fresh object).
3. **No `module.exports = {...}` re-assignment inside `Lib()`** — that would re-introduce the race.
4. **Trailing `module.exports = lib`** anchor still present (documented intent).
5. **Runtime assertion** — a re-require of `lib/index.js` exposes the registry on the captured reference (asserts `lib.merge` is defined after `require()`).

Full suite: 6721 tests, 6719 pass, 2 pre-existing failures (`entity-arguments.test.js`, `entity-injection.test.js`) — both already red on `origin/develop`, unrelated.
