### PR TITLE
controller: add self.setTemplate(file, ext) runtime template override

### DIFF
--- a/framework/v0.3.16-alpha.3/core/controller/controller.js
+++ b/framework/v0.3.16-alpha.3/core/controller/controller.js
@@ -1057,6 +1057,40 @@ function SuperController(options) {
      * @param {boolean} [displayInspector] - Show the Gina dev inspector when `true`
      * @returns {void}
      */
+    /**
+     * Override the route's default template path / extension at action time.
+     *
+     * Use case: a controller action that resolves the template dynamically
+     * (e.g. a catch-all router that picks the template by URL pattern). With
+     * Gina's standard 1:1 routing.json → template mapping the rule's
+     * `param.file` is sufficient, but dynamic dispatch needs a runtime
+     * override that survives until render-time.
+     *
+     * The render delegates (controller.render-nunjucks.js,
+     * controller.render-swig.js) read `localOptions._templateOverride`
+     * before falling back to `data.page.view.file`/`.ext`. Setting this
+     * after `setOptions()` has already populated `data.page.view.*` is the
+     * supported way to redirect rendering from inside an action — that
+     * eviction-order is otherwise unreachable from controller code because
+     * `local.options` is closure-private.
+     *
+     * @memberof BaseController
+     * @param {string} file - Template path relative to the bundle's
+     *                        templates root (no extension; pass `ext` separately).
+     * @param {string} [ext] - File extension (with or without leading dot).
+     *                         Defaults to whatever `data.page.view.ext` carries.
+     */
+    this.setTemplate = function (file, ext) {
+        if (!local.options) return; // setOptions hasn't run yet — bail safely
+        if (!local.options._templateOverride) local.options._templateOverride = {};
+        if (typeof file === 'string') {
+            local.options._templateOverride.file = file;
+        }
+        if (typeof ext === 'string' && ext) {
+            local.options._templateOverride.ext = (ext.charAt(0) === '.') ? ext : ('.' + ext);
+        }
+    };
+
     this.renderWithoutLayout = function (data, displayInspector) {
 
         // preventing multiple call of self.renderWithoutLayout() when controller is rendering from another required controller

--- a/test/core/controller.test.js
+++ b/test/core/controller.test.js
@@ -2321,3 +2321,64 @@ describe('20 - inferAsync: pure logic (#AI6)', function() {
         assert.deepEqual(env.calls.startJob[0].opts, { meta: { kind: 'summary' }, callbackUrl: 'https://x/y' });
     });
 });
+
+
+// self.setTemplate(file, ext) — runtime template override (commit a5f1faa3)
+describe('self.setTemplate(file, ext) — runtime template override', function() {
+
+    var src = fs.readFileSync(SOURCE, 'utf8');
+
+    it('declares this.setTemplate = function (file, ext)', function() {
+        assert.ok(
+            /this\.setTemplate\s*=\s*function\s*\(\s*file\s*,\s*ext\s*\)/.test(src),
+            'expected `this.setTemplate = function (file, ext)` on BaseController — runtime override API was reverted'
+        );
+    });
+
+    it('bails safely when setOptions has not run (no local.options)', function() {
+        var fnMatch = src.match(/this\.setTemplate\s*=\s*function[\s\S]*?\n    \};/);
+        assert.ok(fnMatch, 'setTemplate body not found');
+        var body = fnMatch[0];
+        assert.ok(
+            /if\s*\(!local\.options\)\s*return/.test(body),
+            'expected early-return guard `if (!local.options) return` — would crash when called before setOptions()'
+        );
+    });
+
+    it('writes file/ext under local.options._templateOverride', function() {
+        var fnMatch = src.match(/this\.setTemplate\s*=\s*function[\s\S]*?\n    \};/);
+        var body = fnMatch[0];
+        assert.ok(
+            /local\.options\._templateOverride\.file\s*=\s*file/.test(body),
+            'expected `local.options._templateOverride.file = file` assignment'
+        );
+        assert.ok(
+            /local\.options\._templateOverride\.ext\s*=/.test(body),
+            'expected `local.options._templateOverride.ext = ...` assignment'
+        );
+    });
+
+    it('normalises ext to a leading-dot form', function() {
+        var fnMatch = src.match(/this\.setTemplate\s*=\s*function[\s\S]*?\n    \};/);
+        var body = fnMatch[0];
+        assert.ok(
+            /ext\.charAt\(0\)\s*===\s*'\.'/.test(body),
+            'expected leading-dot normalisation `ext.charAt(0) === "."` — would cause double-dot or missing-dot paths'
+        );
+    });
+
+    it('only accepts string arguments (ignores non-string file/ext)', function() {
+        var fnMatch = src.match(/this\.setTemplate\s*=\s*function[\s\S]*?\n    \};/);
+        var body = fnMatch[0];
+        assert.ok(
+            /typeof\s+file\s*===\s*'string'/.test(body),
+            'expected `typeof file === "string"` guard'
+        );
+        assert.ok(
+            /typeof\s+ext\s*===\s*'string'/.test(body),
+            'expected `typeof ext === "string"` guard'
+        );
+    });
+
+});
+


### PR DESCRIPTION
# controller: add `self.setTemplate(file, ext)` runtime template override

**Commit:** `8e7542a1`
**Target branch:** `develop`
**Files:** `framework/v0.3.16-alpha.3/core/controller/controller.js` (+34 lines), `test/core/controller.test.js` (+61 lines, 5 cases)

## Problem

A controller action that resolves its template dynamically — e.g. a catch-all router that picks the template by URL pattern — needs a runtime mechanism to override the rule's default template path/ext **after** `setOptions()` has already populated `data.page.view.*`. That eviction-order is otherwise unreachable from controller code because `local.options` is closure-private.

The only existing escape hatch is mutating `req.routing.param.file` directly, which works by accident (the render delegate reads it as a fallback) but bypasses `data.page.view.*` and leaves the controller and render layers disagreeing about which file is being rendered.

## Fix

Add a first-class `setTemplate(file, ext)` API on `BaseController`:

```js
this.setTemplate = function (file, ext) {
    if (!local.options) return; // setOptions hasn't run yet — bail safely
    if (!local.options._templateOverride) local.options._templateOverride = {};
    if (typeof file === 'string') {
        local.options._templateOverride.file = file;
    }
    if (typeof ext === 'string' && ext) {
        local.options._templateOverride.ext = (ext.charAt(0) === '.') ? ext : ('.' + ext);
    }
};
```

The render delegates (`controller.render-nunjucks.js`, `controller.render-swig.js`) read `localOptions._templateOverride` before falling back to `data.page.view.file` / `.ext`. The render-side consumer for nunjucks lands in the companion PR #29 (commit `70322199`); the swig delegate already honours the override at its existing fallback site.

## Notes on design

- **No-op when called pre-`setOptions()`** — early `return` rather than throw, since controllers may attempt to call this in init paths that run before route binding.
- **String guards** — silently ignore non-string args. Matches the rest of the controller API surface (no throws for type errors).
- **Leading-dot normalisation** for `ext` so callers can pass `'njk'` or `'.njk'` interchangeably.

## v3 compatibility

Purely additive — no existing controller method is changed. v3 has no `setTemplate` callers and never will under the current per-domain controller pattern. Safe to land.

## Tests

`test/core/controller.test.js` — new `describe('self.setTemplate(file, ext) — runtime template override')` block:

1. **API surface** — `this.setTemplate = function (file, ext)` declared on BaseController.
2. **Pre-setOptions guard** — early-return when `local.options` is absent.
3. **Storage location** — writes `local.options._templateOverride.file` / `.ext`.
4. **Ext normalisation** — `.charAt(0) === '.'` check for leading-dot form.
5. **Type guards** — only `typeof === 'string'` arguments are honoured.
