### PR TITLE
render-swig: treat layoutless renders as top-level scope

### DIFF
--- a/framework/v0.3.16-alpha.3/core/controller/controller.render-swig.js
+++ b/framework/v0.3.16-alpha.3/core/controller/controller.render-swig.js
@@ -510,6 +510,15 @@ module.exports = async function render(userData, displayInspector, errOptions, d
 
         if (!userData) {
             userData = { page: { view: {}}}
+        } else if ( isWithoutLayout ) {
+            // Layoutless renders (self.renderWithoutLayout) have no page envelope
+            // — no `view.layout`, no breadcrumb, no session card — so the
+            // `page`-key-presence gating used below for full pages serves no
+            // purpose here and only buries the controller's context under
+            // `data.page.data`, where the fragment template's top-level
+            // {{ var }} references can't reach it. Merge user context at
+            // top level unconditionally for fragments.
+            data = (isRenderingCustomError) ? userData : merge(userData, data)
         } else if ( userData && !userData['page']) {
 
             if ( typeof(data['page']['data']) == 'undefined' )

--- a/test/core/render-swig.test.js
+++ b/test/core/render-swig.test.js
@@ -1204,3 +1204,47 @@ describe('13 - HTTP/2 response trailers (#H10)', function() {
         assert.strictEqual(matches.length, 5, 'expected 5 stream.respond() calls — trailers must not add respond calls');
     });
 });
+
+
+// Layoutless renders: userData merged at top level (commit a0b40e0a)
+describe('layoutless renders — isWithoutLayout branch merges userData at top level (commit a0b40e0a)', function() {
+
+    var src = function() { return fs.readFileSync(SOURCE, 'utf8'); };
+
+    it('has an `isWithoutLayout` branch in the userData-merge chain', function() {
+        var s = src();
+        // Branch sits between the `!userData` initialiser and the existing `userData && !userData["page"]` gate
+        assert.ok(
+            /if\s*\(!userData\)\s*\{[\s\S]{0,200}\}\s*else if\s*\(\s*isWithoutLayout\s*\)/.test(s),
+            'expected `else if ( isWithoutLayout )` immediately after the `!userData` initialiser — layoutless top-level scope branch was reverted'
+        );
+    });
+
+    it('layoutless branch merges userData at top level (sets `data = merge(userData, data)` shape)', function() {
+        var s = src();
+        // Within the isWithoutLayout branch the assignment must be `data = ... merge(userData, data) ...`
+        // (matches the JSON/raw path), not the `data.page.data = ...` shape used for full pages.
+        var branchMatch = s.match(/else if\s*\(\s*isWithoutLayout\s*\)\s*\{([\s\S]*?)\}\s*else if/);
+        assert.ok(branchMatch, 'could not locate `else if ( isWithoutLayout )` branch body');
+        var body = branchMatch[1];
+        assert.ok(
+            /data\s*=\s*\(isRenderingCustomError\)\s*\?\s*userData\s*:\s*merge\(\s*userData,\s*data\s*\)/.test(body),
+            'expected layoutless branch to assign `data = (isRenderingCustomError) ? userData : merge(userData, data)` — top-level merge was reverted'
+        );
+        assert.ok(
+            !/data\['page'\]\['data'\]\s*=/.test(body),
+            'layoutless branch must NOT bury userData under data.page.data — that is the full-page-render shape'
+        );
+    });
+
+    it('full-page branch (userData has no `page` key) keeps the data.page.data nesting', function() {
+        var s = src();
+        // Zero-change-for-full-pages invariant: the original branch must still exist with its original shape.
+        assert.ok(
+            /else if\s*\(\s*userData\s*&&\s*!userData\['page'\]\s*\)\s*\{[\s\S]*?data\['page'\]\['data'\]\s*=/.test(s),
+            'full-page branch (`userData && !userData["page"]`) must still bury userData under data.page.data — invariant violated'
+        );
+    });
+
+});
+


### PR DESCRIPTION
# render-swig: treat layoutless renders as top-level scope

**Commit:** `94ba1cbe`
**Target branch:** `develop`
**Files:** `framework/v0.3.16-alpha.3/core/controller/controller.render-swig.js` (+9 lines), `test/core/render-swig.test.js` (+44 lines, 3 cases)

## Problem

`self.renderWithoutLayout(ctx)` is the explicit "emit just this template's output, no page chrome" entry point. Fragments by definition have no page envelope (no `view.layout`, no breadcrumb, no session card), so the page-key-presence gating that protects the envelope on full-page renders is wrong for them:

- with no `page` key in `userData`, the whole context gets nested under `data.page.data`
- the fragment template's top-level `{{ var }}` references then resolve to undefined
- the fragment renders empty (HTTP 200, blank body)

The JSON and raw render paths already merge user data at top level. Only the HTML render path through swig had this gap; the nunjucks delegate did not.

## How it surfaced

Downstream bundle (`@designsystem/dashboard`) controllers calling `self.renderWithoutLayout({ projects: ..., total: ... })` against a fragment containing `{{ projects }}` / `{{ total }}` produced HTTP 200 + empty body for every `/api/*` HTML-fragment endpoint after the swig migration. Worked around in that bundle with a `renderFragment(self, ctx)` helper that injected a sentinel `page: {}` to force the `else` branch — this patch removes the need for that workaround.

## Fix

Add an `isWithoutLayout` branch **ahead** of the existing page-key gate that merges `userData` at top level unconditionally for fragments:

```js
if (!userData) {
    userData = { page: { view: {}}}
} else if ( isWithoutLayout ) {
    // Layoutless renders have no page envelope — merge user context at top level.
    data = (isRenderingCustomError) ? userData : merge(userData, data)
} else if ( userData && !userData['page']) {
    // unchanged — full-page-shape stash under data.page.data
    ...
} else {
    // unchanged
    ...
}
```

## Invariant: zero change for full-page renders

The new branch sits **before** the existing `userData && !userData['page']` gate and triggers only when `localOptions.isWithoutLayout` is true. Full-page renders never see this branch — the original `data.page.data = userData` shape is preserved. Verified by a dedicated test below.

## v3 compatibility

v3 renders full pages — `isWithoutLayout` is false on every v3 route. The new branch is unreachable from v3. Safe to land ahead of v3 picking up the next 0.3.16+ Gina pin.

## Tests

`test/core/render-swig.test.js` — new `describe('layoutless renders — isWithoutLayout branch merges userData at top level')` block:

1. **Branch presence** — asserts `else if ( isWithoutLayout )` sits between the `!userData` initialiser and the existing `userData && !userData['page']` gate.
2. **Top-level merge shape** — asserts the branch body uses `data = (isRenderingCustomError) ? userData : merge(userData, data)` and does **not** contain `data['page']['data'] =`.
3. **Full-page invariant** — asserts the original `userData && !userData['page']` branch still nests userData under `data.page.data`.

Full suite: 6721 tests, 6719 pass, 2 pre-existing failures unrelated to this change (`entity-arguments.test.js`, `entity-injection.test.js`) that are already red on `origin/develop`.
