### PR TITLE
render-nunjucks: close three parity gaps with render-swig (depends on #27)

### DIFF
--- a/framework/v0.3.16-alpha.3/core/controller/controller.render-nunjucks.js
+++ b/framework/v0.3.16-alpha.3/core/controller/controller.render-nunjucks.js
@@ -202,6 +202,17 @@ function getEnvironment(nunjucks, templateRoot, options) {
  * @returns {string} relative template path
  */
 function resolveTemplatePath(data, localOptions) {
+    // Honour controller-set override from self.setTemplate(file, ext).
+    // When set, the override fully replaces the rule's default path —
+    // no namespace prefixing — so a catch-all dispatcher can drop the
+    // controller anywhere under the templates root.
+    if (localOptions && localOptions._templateOverride && localOptions._templateOverride.file) {
+        var ovFile = localOptions._templateOverride.file;
+        var ovExt  = localOptions._templateOverride.ext || data.page.view.ext || '';
+        if (ovExt && !ovFile.endsWith(ovExt)) ovFile += ovExt;
+        return ovFile;
+    }
+
     var file = data.page.view.file;
     var ext  = data.page.view.ext || '';
 
@@ -630,6 +641,70 @@ function registerGinaFilters(env, self, local, localOptions, req, res) {
 }
 
 /**
+ * Invoke the bundle's `controllers/setup.js` (if any) with `this.engine`
+ * bound to the cached `nunjucks.Environment`, so user code can call
+ * `engine.addFilter(name, fn)` to extend filters on the nunjucks side
+ * the same way it already can on swig (where `self.engine = swig` is
+ * set by `controller.js:735` before setup runs).
+ *
+ * Without this hook, every nunjucks bundle that uses the documented
+ * setup.js pattern (`var engine = this.engine; engine.addFilter(...)`)
+ * silently no-ops because `this.engine` arrives as the controller's
+ * default `{}` — the nunjucks engine is created lazily here in the
+ * render delegate, after the controller's onReady→setup chain has
+ * already fired.
+ *
+ * Run once per `nunjucks.Environment` instance: marker `_userSetupDone`
+ * is stamped on the env itself so re-renders are no-ops, and a fresh
+ * env (e.g. after `nunjucksResolver.reset()`) re-runs setup.
+ *
+ * @inner
+ * @param {*}      env          - cached `nunjucks.Environment`
+ * @param {object} self         - SuperController instance (provides throwError)
+ * @param {object} local        - per-request closure (`req`, `res`, `next`)
+ * @param {object} localOptions - controller's localOptions (has `bundle`, `conf.bundlesPath`)
+ * @param {object} req          - function-scoped capture of `local.req` (#M1 async-race guard)
+ * @param {object} res          - function-scoped capture of `local.res`
+ * @param {Function} _next      - function-scoped capture of `local.next`
+ * @returns {void}
+ */
+function registerUserFilters(env, self, local, localOptions, req, res, _next) {
+    if (env._userSetupDone) return;
+    if (!localOptions || !localOptions.bundle || !localOptions.conf || !localOptions.conf.bundlesPath) return;
+
+    var setupFile = localOptions.conf.bundlesPath + '/' + localOptions.bundle + '/controllers/setup.js';
+    if (!fs.existsSync(setupFile)) {
+        env._userSetupDone = true; // no setup.js — nothing to do, don't recheck
+        return;
+    }
+
+    var Setup;
+    try {
+        Setup = require(setupFile);
+    } catch (loadErr) {
+        try { console.warn('[render-nunjucks] failed to load user setup.js (' + setupFile + '): ' + (loadErr.message || loadErr)); } catch (e) {}
+        env._userSetupDone = true;
+        return;
+    }
+
+    if (typeof Setup !== 'function') {
+        env._userSetupDone = true;
+        return;
+    }
+
+    Setup.engine     = env;
+    Setup.throwError = self.throwError;
+
+    try {
+        Setup.apply(Setup, [req, res, _next]);
+    } catch (setupErr) {
+        try { console.warn('[render-nunjucks] user setup.js threw: ' + (setupErr.message || setupErr)); } catch (e) {}
+    }
+
+    env._userSetupDone = true;
+}
+
+/**
  * Post-render asset injection — the nunjucks counterpart to the pre-compile
  * layout mutation in `render-swig.js:963-1195`. Idempotent and safe to call
  * on arbitrary HTML: every insertion is guarded against double-injection
@@ -920,15 +995,34 @@ module.exports = async function renderNunjucks(userData, displayInspector, errOp
         ));
     }
 
-    // Merge user data into page.data so templates can access via {{ page.data.foo }}
-    // or {{ foo }} at top level (promoted for ergonomic parity with swig).
-    // FRAMEWORK PATCH: the comment promised top-level promotion but
-    // the original code only wrote to data.page.data. Mirror to top-level too.
+    // Merge user data into the render context, mirroring `render-swig.js:480-517`.
+    // Swig does two things to userData:
+    //
+    //   (a) Branching stash — if userData has no `page` key, copy it into
+    //       `data.page.data`. If userData has a `page` key, skip the stash.
+    //   (b) Unconditional top-level merge — userData wins on collision with
+    //       framework-populated keys, matching swig's `merge(data, getData())`.
+    //
+    // Without (b), nunjucks templates that mirror swig-style usage
+    // (`{{ client }}`, `{{ settings.terms.estimate }}`) silently render
+    // empty when the controller passes a flat object — `for` loops iterate
+    // 0 times, `set e = estimate` binds undefined, etc.
     if (userData && typeof(userData) === 'object') {
-        if (!data.page.data) { data.page.data = {}; }
+        // (a) Branching stash
+        if (!userData.page) {
+            if (!data.page.data) { data.page.data = {}; }
+            Object.keys(userData).forEach(function (k) {
+                data.page.data[k] = userData[k];
+            });
+        }
+        // (b) Unconditional top-level merge — userData wins; userData.page
+        // merges INTO data.page (preserves framework-injected page.view etc.).
         Object.keys(userData).forEach(function (k) {
-            data.page.data[k] = userData[k];
-            if (typeof(data[k]) === 'undefined') {
+            if (k === 'page' && data.page && typeof userData.page === 'object') {
+                Object.keys(userData.page).forEach(function (pk) {
+                    data.page[pk] = userData.page[pk];
+                });
+            } else {
                 data[k] = userData[k];
             }
         });
@@ -963,6 +1057,16 @@ module.exports = async function renderNunjucks(userData, displayInspector, errOp
         registerGinaFilters(env, self, local, localOptions, req, res);
     } catch (filterErr) {
         return self.throwError(filterErr);
+    }
+
+    // #NJ1b — give the bundle's controllers/setup.js a chance to extend
+    // filters via `this.engine.addFilter(...)`, mirroring the swig path
+    // where `self.engine = swig` is set in controller.js before setup runs.
+    // No-op if no setup.js exists or it doesn't add filters.
+    try {
+        registerUserFilters(env, self, local, localOptions, req, res, _next);
+    } catch (userFilterErr) {
+        try { console.warn('[render-nunjucks] registerUserFilters failed: ' + (userFilterErr.message || userFilterErr)); } catch (e) {}
     }
 
     // #NJ2 — build the per-request template config and populate

--- a/test/core/render-nunjucks.test.js
+++ b/test/core/render-nunjucks.test.js
@@ -349,3 +349,115 @@ describe('03 - HTTP/2 response trailers (#H10)', function() {
         );
     });
 });
+
+
+// Bundle-compat parity with swig (commit bf474621): three independent edits.
+describe('bundle-compat parity with render-swig (commit bf474621)', function() {
+
+    var _src;
+    function src() { return _src || (_src = fs.readFileSync(SOURCE, 'utf8')); }
+
+    // (1) resolveTemplatePath honours self.setTemplate() override
+    describe('resolveTemplatePath honours _templateOverride', function() {
+
+        it('declares resolveTemplatePath(data, localOptions)', function() {
+            assert.ok(
+                /function\s+resolveTemplatePath\s*\(\s*data\s*,\s*localOptions\s*\)/.test(src()),
+                'expected `function resolveTemplatePath(data, localOptions)` — helper signature changed or reverted'
+            );
+        });
+
+        it('checks localOptions._templateOverride.file before falling back to data.page.view.file', function() {
+            var s = src();
+            var fnMatch = s.match(/function\s+resolveTemplatePath[\s\S]*?\n\}/);
+            assert.ok(fnMatch, 'resolveTemplatePath body not found');
+            var body = fnMatch[0];
+            assert.ok(
+                /localOptions\s*&&\s*localOptions\._templateOverride\s*&&\s*localOptions\._templateOverride\.file/.test(body),
+                'expected _templateOverride.file guard in resolveTemplatePath — setTemplate() honour was reverted'
+            );
+            assert.ok(
+                /var\s+ovFile\s*=\s*localOptions\._templateOverride\.file/.test(body),
+                'expected `var ovFile = localOptions._templateOverride.file` capture'
+            );
+        });
+
+        it('override path skips the namespace prefix block', function() {
+            // The override returns ovFile directly before reaching the
+            // `if (localOptions.namespace)` block further down.
+            var s = src();
+            var fnMatch = s.match(/function\s+resolveTemplatePath[\s\S]*?\n\}/);
+            var body = fnMatch[0];
+            var overrideReturn = body.indexOf('return ovFile');
+            var nsBlock = body.indexOf('localOptions.namespace');
+            assert.ok(overrideReturn > -1, 'expected `return ovFile` early-exit in override branch');
+            assert.ok(nsBlock > overrideReturn, 'override must return before reaching the namespace block (no namespace prefixing)');
+        });
+    });
+
+    // (2) registerUserFilters invokes setup.js with this.engine bound
+    describe('registerUserFilters invokes setup.js with this.engine bound to nunjucks env', function() {
+
+        it('declares registerUserFilters with captured req/res/_next params (#M1 async-race guard)', function() {
+            assert.ok(
+                /function\s+registerUserFilters\s*\(\s*env\s*,\s*self\s*,\s*local\s*,\s*localOptions\s*,\s*req\s*,\s*res\s*,\s*_next\s*\)/.test(src()),
+                'expected `function registerUserFilters(env, self, local, localOptions, req, res, _next)` — captured-locals pattern (mirrors registerGinaFilters); reading local.req/res/next inside the helper would re-introduce the #M1 async-race read'
+            );
+        });
+
+        it('Setup.apply uses captured req/res/_next, not local.req/res/next', function() {
+            var s = src();
+            // The setup invocation must read from the captured locals.
+            assert.ok(
+                /Setup\.apply\(\s*Setup\s*,\s*\[\s*req\s*,\s*res\s*,\s*_next\s*\]\s*\)/.test(s),
+                'expected `Setup.apply(Setup, [req, res, _next])` using captured locals — reading local.req/res/next here defeats the #M1 retrofit'
+            );
+            assert.ok(
+                !/Setup\.apply\(\s*Setup\s*,\s*\[\s*local\.req/.test(s),
+                'must NOT call Setup.apply with [local.req, local.res, local.next] — captured locals only'
+            );
+        });
+
+        it('is guarded by an `env._userSetupDone` idempotency marker', function() {
+            var s = src();
+            assert.ok(
+                /if\s*\(\s*env\._userSetupDone\s*\)\s*return/.test(s),
+                'expected idempotency early-return `if (env._userSetupDone) return` — would re-run setup.js per render'
+            );
+            assert.ok(
+                /env\._userSetupDone\s*=\s*true/.test(s),
+                'expected env._userSetupDone marker to be set after setup invocation'
+            );
+        });
+    });
+
+    // (3) userData merge mirrors render-swig.js — unconditional top-level merge
+    describe('userData merge mirrors render-swig (unconditional top-level merge; userData.page merges INTO data.page)', function() {
+
+        it('merges userData.page INTO data.page rather than clobbering it', function() {
+            var s = src();
+            // The post-patch loop iterates userData.page keys and writes onto
+            // data.page key-by-key, preserving framework-injected page.view etc.
+            assert.ok(
+                /k\s*===\s*'page'[\s\S]{0,160}Object\.keys\(\s*userData\.page\s*\)\.forEach/.test(s),
+                'expected `k === "page"` branch with `Object.keys(userData.page).forEach` — clobber-mode (data.page = userData.page) would erase view metadata'
+            );
+            assert.ok(
+                /data\.page\[\s*pk\s*\]\s*=\s*userData\.page\[\s*pk\s*\]/.test(s),
+                'expected per-key write `data.page[pk] = userData.page[pk]` inside the page-merge branch'
+            );
+        });
+
+        it('keeps the data.page.data stash for the !userData.page branch', function() {
+            // The full-page-shape stash must still exist for templates that branch on layout-dependent shapes.
+            var s = src();
+            assert.ok(
+                /data\.page\.data\s*=/.test(s),
+                'expected data.page.data assignment to remain for full-page-shape stash'
+            );
+        });
+
+    });
+
+});
+


### PR DESCRIPTION
# render-nunjucks: three parity gaps with render-swig

**Commit:** `70322199`
**Target branch:** `develop`
**Depends on:** #27 (`setTemplate` controller API, commit `8e7542a1`)
**Files:** `framework/v0.3.16-alpha.3/core/controller/controller.render-nunjucks.js` (+111, –7), `test/core/render-nunjucks.test.js` (+112 lines, 8 cases)

## Problem

Three independent gaps where `controller.render-nunjucks.js` diverged from `controller.render-swig.js`. Each one is a silent compat issue — code that works on swig-rendered bundles renders empty or no-ops on nunjucks-rendered ones.

### 1. `resolveTemplatePath()` ignored `self.setTemplate()` override

`setTemplate(file, ext)` (PR #02) writes `localOptions._templateOverride`. The swig render path reads it at its existing path-construction site. The nunjucks `resolveTemplatePath()` helper read `data.page.view.file` / `.ext` directly and never checked the override → `setTemplate()` was a silent no-op on nunjucks bundles.

### 2. `setup.js` ran with an empty `this.engine`

Convention: bundles extend filters by writing `engine.addFilter(name, fn)` in `controllers/setup.js`, where `engine` is `this.engine`.

- **swig path**: `this.engine = swig` is set in `controller.js:735` before the `onReady → setup` chain fires. `setup.js` sees the real engine.
- **nunjucks path**: the `nunjucks.Environment` was created lazily inside the render delegate, *after* `setup.js` had already run with `this.engine = {}`. `engine.addFilter` was a no-op on the placeholder, and the documented setup pattern silently failed for every nunjucks bundle.

### 3. `userData` merge was framework-wins, not user-wins

- **swig**: `merge(data, getData())` unconditionally — `userData` wins on collision.
- **nunjucks** (pre-patch): stashed `userData` into `data.page.data` and only filled top-level `data[k]` when undefined — framework wins collisions.

Templates that mirror swig usage (`{{ client }}`, `{{ settings.terms.estimate }}`) rendered empty on nunjucks when the controller passed a flat object; templates that branch on layout-dependent shapes fell into the wrong branch.

## Fix

### 1. `resolveTemplatePath` honours `_templateOverride`

```js
function resolveTemplatePath(data, localOptions) {
    if (localOptions && localOptions._templateOverride && localOptions._templateOverride.file) {
        var ovFile = localOptions._templateOverride.file;
        var ovExt  = localOptions._templateOverride.ext || data.page.view.ext || '';
        if (ovExt && !ovFile.endsWith(ovExt)) ovFile += ovExt;
        return ovFile;            // fully replaces the rule path; no namespace prefixing
    }
    // ... existing namespace-aware resolution unchanged
}
```

Override return is **early**, before the `localOptions.namespace` block — a catch-all dispatcher can drop a controller anywhere under the templates root without fighting the namespace prefix.

### 2. `registerUserFilters(env, self, local, localOptions, req, res, _next)`

Invoked once the `nunjucks.Environment` exists. Re-runs `setup.js` with `this.engine` bound to that env, gated by an idempotency marker `env._userSetupDone` so subsequent renders skip it.

**`#M1` async-race guard.** The helper takes captured `req` / `res` / `_next` parameters and uses them in `Setup.apply(Setup, [req, res, _next])` — mirroring the sibling `registerGinaFilters(env, self, local, localOptions, req, res)`. Reading `local.req` / `local.res` / `local.next` inside the helper would defeat the `#M1` async-race retrofit (terminal-exit closure nulling): those properties can be nulled between awaits by `throwError`'s closure-cleanup. The accompanying test `Setup.apply uses captured req/res/_next, not local.req/res/next` pins this.

### 3. `userData` merge mirrors swig

Branching stash + unconditional top-level merge, with `userData.page` merged **into** `data.page` key-by-key rather than clobbering — so framework-injected `page.view` (and friends) survive when a controller passes its own `page` subtree.

```js
if (userData && typeof userData === 'object') {
    if (!userData.page) {
        Object.keys(userData).forEach(function (k) {
            data.page.data[k] = userData[k];   // (a) stash for full-page-shape templates
        });
    }
    // (b) unconditional top-level merge — userData wins; userData.page merges INTO data.page
    Object.keys(userData).forEach(function (k) {
        if (k === 'page' && data.page && typeof userData.page === 'object') {
            Object.keys(userData.page).forEach(function (pk) {
                data.page[pk] = userData.page[pk];
            });
        } else {
            data[k] = userData[k];
        }
    });
}
```

## v3 compatibility

v3 runs the **swig** delegate, not nunjucks. The entire surface area of this PR is inert for v3 — `controller.render-nunjucks.js` is not loaded. Safe to land.

## Tests

`test/core/render-nunjucks.test.js` — new `describe('bundle-compat parity with render-swig')` block, three nested describes mirroring the three edits:

1. **`resolveTemplatePath honours _templateOverride`** — helper signature, `_templateOverride.file` guard, early `return ovFile` before the namespace block.
2. **`registerUserFilters invokes setup.js with this.engine bound`** — full signature `(env, self, local, localOptions, req, res, _next)` (#M1 captured-locals pattern), `env._userSetupDone` idempotency marker, and `Setup.apply(Setup, [req, res, _next])` using captured locals — must NOT use `local.req/res/next`.
3. **`userData merge mirrors render-swig`** — `k === 'page'` branch with `Object.keys(userData.page).forEach`, per-key write `data.page[pk] = userData.page[pk]`, and the full-page-shape `data.page.data = ...` stash still present.

Full suite: 6721 tests, 6719 pass, 2 pre-existing failures (`entity-arguments.test.js`, `entity-injection.test.js`) — both already red on `origin/develop`, unrelated.
